### PR TITLE
Allowed server to be started and stopped an infintum

### DIFF
--- a/server.go
+++ b/server.go
@@ -283,6 +283,7 @@ func (s *Server) Kill() error {
 			return err
 		}
 	}
+	s.connections = []net.PacketConn{}
 
 	for _, listener := range s.listeners {
 		err := listener.Close()
@@ -290,6 +291,8 @@ func (s *Server) Kill() error {
 			return err
 		}
 	}
+	s.listeners = []net.Listener{}
+
 	// Only need to close channel once to broadcast to all waiting
 	if s.doneTcp != nil {
 		close(s.doneTcp)


### PR DESCRIPTION
Currently this causes an error:

```go
package main

import (
        "fmt"
        "time"

        log "github.com/Sirupsen/logrus"

        syslog "github.com/RenaultAI/go-syslog"
)

var server *syslog.Server

func start() {
        port := 9344
        if err := server.ListenUDP(fmt.Sprintf("0.0.0.0:%d", port)); err != nil {
                log.Fatal(err)
        }

        if err := server.ListenTCP(fmt.Sprintf("0.0.0.0:%d", port)); err != nil {
                log.Fatal(err)
        }

        if err := server.Boot(); err != nil {
                log.Fatal(err)
        }

        log.WithFields(log.Fields{"ref": "syslog", "at": "start", "port": port}).Info()
}
func stop() {
        log.Info("Stopping")
        if err := server.Kill(); err != nil {
                log.Printf(err.Error())
                log.Errorf(server.Kill().Error())
        }
}

func main() {
        channel := make(syslog.LogPartsChannel)
        handler := syslog.NewChannelHandler(channel)
        go func() {
                for {
                        x := <-channel
                        log.Printf("%+v", x)
                }
        }()

        server = syslog.NewServer()
        server.SetFormat(syslog.Automatic)
        server.SetHandler(handler)

        start()

        time.Sleep(5 * time.Second)

        stop()

        time.Sleep(5 * time.Second)

        start()

        time.Sleep(5 * time.Second)

        stop()

        time.Sleep(5 * time.Second)

        start()

        time.Sleep(5 * time.Minute)

}
```

You can start, stop, and start again a listener perfectly.  The problem happens on the second `server.Kill()`.  Because the server is not _removing its closed connections_ from server.listeners and server.connections.

This cleans up, setting the state to empty slices, after successful Close()'ing