### PR TITLE
fix(tcp-listen/panic): check for tcp shutdown closer to message use

### DIFF
--- a/servertls_test.go
+++ b/servertls_test.go
@@ -73,6 +73,7 @@ func (s *ServerSuite) TestTLS(c *C) {
 		if _, err := io.WriteString(conn, fmt.Sprintf("%s\n", exampleSyslog)); err != nil {
 			panic(err)
 		}
+		time.Sleep(10 * time.Millisecond) // sleep to handle message async
 		server.Kill()
 	}(server)
 	server.Wait()


### PR DESCRIPTION
Previously, if we took a while getting the message we may have shut
down the server in the mean time, causing a send on a closed channel
(due to failure to check and abort the go-routine handling messages).